### PR TITLE
Shorten DNS record updating

### DIFF
--- a/deployment/update-gcp-dns.sh
+++ b/deployment/update-gcp-dns.sh
@@ -22,6 +22,12 @@ function get_external_ip() {
     "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip"
 }
 
+function get_current_ip() {
+  local domain="$1"
+  
+  dig @1.1.1.1 +short "${domain}."
+}
+
 function update_record() {
   local zone_project zone domain ip
   zone_project="$1"
@@ -36,9 +42,12 @@ function update_record() {
    --zone="$zone"
 }
 
-current_ip=""
+apt install -y dnsutils
 
 while [ 1 ]; do
+  current_ip="$(get_current_ip "$DOMAIN")"
+  printf "resolved current IP as %s\n" "${current_ip}"
+  
   public_ip="$(get_external_ip)"
   printf "resolved external IP as %s\n" "${public_ip}"
 
@@ -48,6 +57,6 @@ while [ 1 ]; do
     printf "updated %s to %s\n" "${DOMAIN}" "${current_ip}"
   fi
 
-  echo "-> sleeping for 300s"
-  sleep 300
+  echo "-> sleeping for 15s"
+  sleep 15
 done


### PR DESCRIPTION
I've shortened the DNS update checks so that upon resuming an instance, the DNS record is updated quicker. 

I've opted to not support suspending right now, as it terminates the instance after 60 hours when I'd just like the instance to be stopped instead.